### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@v5
       with:
@@ -21,5 +21,5 @@ jobs:
         registry: ghcr.io
         default_branch: main
         workdir: inst/database
-        tags: "latest"
+        tags: ${{ github.ref_name }}
         tag_semver: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: jimbrig/lossrx/actuarialdb
         username: ${{ github.actor }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore