### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,16 +27,16 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: r-lib/actions/setup-pandoc@v1
-      - uses: r-lib/actions/setup-r@v1
+      - uses: actions/checkout@v3.5.0
+      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
 
-      - uses: r-lib/actions/check-r-package@v1
+      - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,13 +17,13 @@ jobs:
       CODCOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.0
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: covr
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,9 +11,9 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3.5.0
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: jimbrig/lossrx/actuarialdb
         username: ${{ github.actor }}

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -9,9 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.5.0
     - name: Create a Release
-      uses: elgohr/Github-Release-Action@v4
+      uses: elgohr/Github-Release-Action@20220921051011
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       with:

--- a/.github/workflows/gha-versions.yml
+++ b/.github/workflows/gha-versions.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/git-cliff.yml
+++ b/.github/workflows/git-cliff.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.5.0
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v1
+        uses: orhun/git-cliff-action@v2.0.5
         id: git-cliff
         with:
           config: ./cliff.toml
@@ -30,6 +30,6 @@ jobs:
         run: cat "${{ steps.git-cliff.outputs.changelog }}"
 
       - name: Commit and Push Changes
-        uses: actions-js/push@master
+        uses: actions-js/push@v1.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -11,8 +11,8 @@ jobs:
   labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: micnncim/action-label-syncer@v1
+      - uses: actions/checkout@v3.5.0
+      - uses: micnncim/action-label-syncer@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/linguist.yml
+++ b/.github/workflows/linguist.yml
@@ -7,8 +7,8 @@ jobs:
     name: Run linguist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - uses: fabasoad/linguist-action@main
+      - uses: actions/checkout@v3.5.0
+      - uses: fabasoad/linguist-action@v1.0.4
         id: linguist
         with:
           path: './'

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -13,15 +13,15 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.0
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: pkgdown
           needs: website

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -8,5 +8,5 @@ jobs:
     name: Generate-TOC
     runs-on: ubuntu-latest
     steps:
-      - uses: technote-space/toc-generator@v4
+      - uses: technote-space/toc-generator@v4.3.1
   


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.0](https://github.com/actions/checkout/releases/tag/v3.5.0)** on 2023-03-24T05:41:31Z
* **[actions-js/push](https://github.com/actions-js/push)** published a new release **[v1.4](https://github.com/actions-js/push/releases/tag/v1.4)** on 2022-12-18T09:43:10Z
* **[elgohr/Publish-Docker-Github-Action](https://github.com/elgohr/Publish-Docker-Github-Action)** published a new release **[v5](https://github.com/elgohr/Publish-Docker-Github-Action/releases/tag/v5)** on 2022-11-30T19:58:28Z
* **[elgohr/Github-Release-Action](https://github.com/elgohr/Github-Release-Action)** published a new release **[20220921051011](https://github.com/elgohr/Github-Release-Action/releases/tag/20220921051011)** on 2022-09-21T05:10:12Z
* **[fabasoad/linguist-action](https://github.com/fabasoad/linguist-action)** published a new release **[v1.0.4](https://github.com/fabasoad/linguist-action/releases/tag/v1.0.4)** on 2022-05-13T15:22:23Z
* **[r-lib/actions](https://github.com/r-lib/actions)** published a new release **[v2](https://github.com/r-lib/actions/releases/tag/v2)** on 2021-12-12T17:39:09Z
* **[technote-space/toc-generator](https://github.com/technote-space/toc-generator)** published a new release **[v4.3.1](https://github.com/technote-space/toc-generator/releases/tag/v4.3.1)** on 2022-12-11T10:37:40Z
* **[orhun/git-cliff-action](https://github.com/orhun/git-cliff-action)** published a new release **[v2.0.5](https://github.com/orhun/git-cliff-action/releases/tag/v2.0.5)** on 2023-02-06T11:00:32Z
* **[micnncim/action-label-syncer](https://github.com/micnncim/action-label-syncer)** published a new release **[v1.3.0](https://github.com/micnncim/action-label-syncer/releases/tag/v1.3.0)** on 2021-05-23T03:04:28Z
