### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/linguist.yml
+++ b/.github/workflows/linguist.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.5.2
-      - uses: fabasoad/linguist-action@v1.0.4
+      - uses: fabasoad/linguist-action@v1.0.5
         id: linguist
         with:
           path: './'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[fabasoad/linguist-action](https://github.com/fabasoad/linguist-action)** published a new release **[v1.0.5](https://github.com/fabasoad/linguist-action/releases/tag/v1.0.5)** on 2023-06-01T01:20:18Z
