### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3.5.3
     - name: Create a Release
-      uses: elgohr/Github-Release-Action@20220921051011
+      uses: elgohr/Github-Release-Action@20230626184259
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[elgohr/Github-Release-Action](https://github.com/elgohr/Github-Release-Action)** published a new release **[20230626184259](https://github.com/elgohr/Github-Release-Action/releases/tag/20230626184259)** on 2023-06-26T18:43:00Z
