### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -52,7 +52,7 @@ jobs:
           LINTR_ERROR_ON_LINT: false
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@codeql-bundle-20230524
         with:
           sarif_file: lintr-results.sarif
           wait-for-processing: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230524](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230524)** on 2023-05-24T16:01:13Z
