### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
       CODCOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -45,7 +45,7 @@ jobs:
         
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.6.0
+    - uses: actions/checkout@v4.0.0
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@v5
       with:

--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -11,7 +11,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.6.0
+    - uses: actions/checkout@v4.0.0
     - name: Create a Release
       uses: elgohr/Github-Release-Action@20230626184259
       env:

--- a/.github/workflows/gha-versions.yml
+++ b/.github/workflows/gha-versions.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
         with:
           token: ${{ secrets.WORKFLOW_SECRET }}
 

--- a/.github/workflows/git-cliff.yml
+++ b/.github/workflows/git-cliff.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -11,7 +11,7 @@ jobs:
   labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
       - uses: micnncim/action-label-syncer@v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linguist.yml
+++ b/.github/workflows/linguist.yml
@@ -7,7 +7,7 @@ jobs:
     name: Run linguist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
       - uses: fabasoad/linguist-action@v1.0.5
         id: linguist
         with:

--- a/.github/workflows/lint-changes.yml
+++ b/.github/workflows/lint-changes.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
 
       - uses: r-lib/actions/setup-r@v2
 

--- a/.github/workflows/lintr.yml
+++ b/.github/workflows/lintr.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.0.0
 
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
@@ -52,7 +52,7 @@ jobs:
           LINTR_ERROR_ON_LINT: false
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@codeql-bundle-20230524
         with:
           sarif_file: lintr-results.sarif
           wait-for-processing: true

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3.6.0
+      - uses: actions/checkout@v4.0.0
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -11,7 +11,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3.6.0
+        uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0)** on 2023-09-04T12:22:57Z
* **[github/codeql-action](https://github.com/github/codeql-action)** published a new release **[codeql-bundle-20230524](https://github.com/github/codeql-action/releases/tag/codeql-bundle-20230524)** on 2023-05-24T16:01:13Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v3.1.3](https://github.com/actions/upload-artifact/releases/tag/v3.1.3)** on 2023-09-06T19:16:46Z
