### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/git-cliff.yml
+++ b/.github/workflows/git-cliff.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v2.2.0
+        uses: orhun/git-cliff-action@v2.3.0
         id: git-cliff
         with:
           config: ./cliff.toml


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[orhun/git-cliff-action](https://github.com/orhun/git-cliff-action)** published a new release **[v2.3.0](https://github.com/orhun/git-cliff-action/releases/tag/v2.3.0)** on 2023-11-12T22:26:08Z
