### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.1
     - name: Create a Release
-      uses: elgohr/Github-Release-Action@20231005120738
+      uses: elgohr/Github-Release-Action@20231116201936
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       with:

--- a/.github/workflows/git-cliff.yml
+++ b/.github/workflows/git-cliff.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v2.2.0
+        uses: orhun/git-cliff-action@v2.3.0
         id: git-cliff
         with:
           config: ./cliff.toml


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[orhun/git-cliff-action](https://github.com/orhun/git-cliff-action)** published a new release **[v2.3.0](https://github.com/orhun/git-cliff-action/releases/tag/v2.3.0)** on 2023-11-12T22:26:08Z
* **[elgohr/Github-Release-Action](https://github.com/elgohr/Github-Release-Action)** published a new release **[20231116201936](https://github.com/elgohr/Github-Release-Action/releases/tag/20231116201936)** on 2023-11-16T20:19:37Z
