### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/gh-release.yml
+++ b/.github/workflows/gh-release.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4.1.1
     - name: Create a Release
-      uses: elgohr/Github-Release-Action@20231005120738
+      uses: elgohr/Github-Release-Action@20231116201936
       env:
         GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       with:


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[elgohr/Github-Release-Action](https://github.com/elgohr/Github-Release-Action)** published a new release **[20231116201936](https://github.com/elgohr/Github-Release-Action/releases/tag/20231116201936)** on 2023-11-16T20:19:37Z
