### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
         
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.4.3
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false
           branch: gh-pages

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -44,7 +44,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache styler
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v3.3.3
         with:
           path: ${{ steps.styler-location.outputs.location }}
           key: ${{ runner.os }}-styler-${{ github.sha }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action)** published a new release **[v4.5.0](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.5.0)** on 2023-11-28T03:09:56Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.0.0](https://github.com/actions/upload-artifact/releases/tag/v4.0.0)** on 2023-12-14T16:38:02Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.3](https://github.com/actions/cache/releases/tag/v3.3.3)** on 2024-01-11T16:38:48Z
