### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
         
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/.github/workflows/git-cliff.yml
+++ b/.github/workflows/git-cliff.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate a changelog
-        uses: orhun/git-cliff-action@v2.3.0
+        uses: orhun/git-cliff-action@v3.0.1
         id: git-cliff
         with:
           config: ./cliff.toml

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.4.3
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false
           branch: gh-pages

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -44,7 +44,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache styler
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v4.0.0
         with:
           path: ${{ steps.styler-location.outputs.location }}
           key: ${{ runner.os }}-styler-${{ github.sha }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.3.1](https://github.com/actions/upload-artifact/releases/tag/v4.3.1)** on 2024-02-05T21:40:25Z
* **[JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action)** published a new release **[v4.5.0](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.5.0)** on 2023-11-28T03:09:56Z
* **[orhun/git-cliff-action](https://github.com/orhun/git-cliff-action)** published a new release **[v3.0.1](https://github.com/orhun/git-cliff-action/releases/tag/v3.0.1)** on 2024-02-21T17:18:41Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.0](https://github.com/actions/cache/releases/tag/v4.0.0)** on 2024-01-16T22:17:55Z
