### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -44,7 +44,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache styler
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4.0.2
         with:
           path: ${{ steps.styler-location.outputs.location }}
           key: ${{ runner.os }}-styler-${{ github.sha }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
